### PR TITLE
Update from skeleton and add post-packer Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ inner workings:
 
 After the AMI has been successfully created, you may want to allow other
 accounts in your AWS organization permission to launch it.  For this project,
-we want to allow all accounts whose names begin with "env" to launch the
+we want to allow the "Shared Services" account to launch the
 most-recently-created AMI.  To do that, follow these instructions:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ your AWS credentials file:
 * `cool-users-provisionaccount`
 
 The easiest way to set up those profiles is to use our
-[aws-profile-sync](https://github.com/cisagov/aws-profile-sync) utility.
+[`aws-profile-sync`](https://github.com/cisagov/aws-profile-sync) utility.
 Follow the usage instructions in that repository before continuing with the
 next steps.  Note that you will need to know where your team stores their
 remote profile data in order to use
-[aws-profile-sync](https://github.com/cisagov/aws-profile-sync).
+[`aws-profile-sync`](https://github.com/cisagov/aws-profile-sync).
 
 To create the build user, follow these instructions:
 
@@ -120,9 +120,9 @@ The [Packer template](src/packer.json) requires two environment variables to be 
 Additionally, the following optional environment variables can be used
 by the [Packer template](src/packer.json) to tag the final image:
 
-* `GITHUB_IS_PRERELEASE`: Boolean pre-release status
-* `GITHUB_RELEASE_TAG`: Image version
-* `GITHUB_RELEASE_URL`: URL pointing to the related GitHub release
+* `GITHUB_IS_PRERELEASE`: Boolean pre-release status.
+* `GITHUB_RELEASE_TAG`: Image version.
+* `GITHUB_RELEASE_URL`: URL pointing to the related GitHub release.
 
 Here is an example of how to kick off a pre-release build:
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ inner workings:
 ./patch_packer_config.py --help
 ```
 
+### Giving Other AWS Accounts Permission to Launch the Image ###
+
+After the AMI has been successfully created, you may want to allow other
+accounts in your AWS organization permission to launch it.  For this project,
+we want to allow all accounts whose names begin with "env" to launch the
+most-recently-created AMI.  To do that, follow these instructions:
+
+```console
+cd terraform-post-packer
+terraform init --upgrade=true
+terraform apply
+```
+
 ## Contributing ##
 
 We welcome contributions!  Please see [here](CONTRIBUTING.md) for

--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -16,12 +16,12 @@ provider "aws" {
 data "aws_caller_identity" "images" {
 }
 
-# The most-recent AMI created by cisagov/skeleton-packer-cool
-data "aws_ami" "example" {
+# The most-recent AMI created by cisagov/freeipa-client-packer
+data "aws_ami" "freeipa_client" {
   filter {
     name = "name"
     values = [
-      "example-hvm-*-x86_64-ebs",
+      "freeipa-client-hvm-*-x86_64-ebs",
     ]
   }
 
@@ -48,6 +48,6 @@ module "ami_launch_permission" {
     aws.master = aws.master
   }
 
-  account_name_regex = "^env"
-  ami_id             = data.aws_ami.example.id
+  account_name_regex = "^Shared Services$"
+  ami_id             = data.aws_ami.freeipa_client.id
 }

--- a/terraform-post-packer/main.tf
+++ b/terraform-post-packer/main.tf
@@ -1,0 +1,53 @@
+# Default AWS provider (EC2AMICreate role in the Images account)
+provider "aws" {
+  region  = "us-east-1"
+  profile = "cool-images-ec2amicreate"
+}
+
+# AWS provider for the Master account (OrganizationsReadOnly role)
+provider "aws" {
+  region  = "us-east-1"
+  profile = "cool-master-organizationsreadonly"
+  alias   = "master"
+}
+
+# Use aws_caller_identity with the default provider (Images account)
+# so we can provide the Images account ID below
+data "aws_caller_identity" "images" {
+}
+
+# The most-recent AMI created by cisagov/skeleton-packer-cool
+data "aws_ami" "example" {
+  filter {
+    name = "name"
+    values = [
+      "example-hvm-*-x86_64-ebs",
+    ]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  owners      = [data.aws_caller_identity.images.account_id]
+  most_recent = true
+}
+
+# Assign launch permissions to the AMI
+module "ami_launch_permission" {
+  source = "github.com/cisagov/ami-launch-permission-tf-module"
+
+  providers = {
+    aws        = aws
+    aws.master = aws.master
+  }
+
+  account_name_regex = "^env"
+  ami_id             = data.aws_ami.example.id
+}

--- a/terraform-post-packer/outputs.tf
+++ b/terraform-post-packer/outputs.tf
@@ -1,0 +1,4 @@
+output "accounts" {
+  value       = module.ami_launch_permission.accounts
+  description = "A map whose keys are the account names allowed to launch the AMI and whose values are the account IDs and the AMI ID."
+}

--- a/terraform-post-packer/terraform.tf
+++ b/terraform-post-packer/terraform.tf
@@ -5,6 +5,6 @@ terraform {
     dynamodb_table = "terraform-state-lock"
     profile        = "cool-terraform-backend"
     region         = "us-east-1"
-    key            = "skeleton-packer-cool/terraform-post-packer.tfstate"
+    key            = "freeipa-client-packer/terraform-post-packer.tfstate"
   }
 }

--- a/terraform-post-packer/terraform.tf
+++ b/terraform-post-packer/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    encrypt        = true
+    bucket         = "cisa-cool-terraform-state"
+    dynamodb_table = "terraform-state-lock"
+    profile        = "cool-terraform-backend"
+    region         = "us-east-1"
+    key            = "skeleton-packer-cool/terraform-post-packer.tfstate"
+  }
+}


### PR DESCRIPTION
# <!--- Provide a general summary of your changes in the Title above -->

## 🗣 Description
This PR pulls in the latest changes from [`skeleton-packer-cool`](https://github.com/cisagov/skeleton-packer-cool).  The primary change is the addition of Terraform that can modify the most-recently-created AMI so that it can be launched from the COOL Shared Services account (thanks to https://github.com/cisagov/ami-launch-permission-tf-module).
<!--- Describe your changes in detail -->

## 💭 Motivation and Context
In order for this AMI to be useful to us, it must be made available to the Shared Services account.  This PR provides a simple and consistent way to accomplish that every time a new AMI is created.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## 🧪 Testing
I ran a `terraform apply` with these changes and verified that launch permission (for the latest FreeIPA Client AMI) was granted to the Shared Services account.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.